### PR TITLE
Fix for SingleClientConnManager state warning on failed requests

### DIFF
--- a/src/com/buddycloud/http/BuddycloudHTTPHelper.java
+++ b/src/com/buddycloud/http/BuddycloudHTTPHelper.java
@@ -167,6 +167,9 @@ public class BuddycloudHTTPHelper {
 				}
 				HttpResponse response = CLIENT.execute(method);
 				if (response.getStatusLine().getStatusCode() >= 400) {
+					// Make sure entity is consumed (released) so connection can be re-used
+					// this avoids the SingleClientConnManager warning about invalid status connection not released
+					response.getEntity().consumeContent();
 					throw new Exception(response.getStatusLine().toString());
 				}
 				


### PR DESCRIPTION
This fixes the warning in the logs about SingleClientConnManager when any http request fails, basically it wasnt allowing the resources to be released between request. Just need to make the the entity in the response DOES get handled even in an error state.
