### PR TITLE
Fix existing memory leak in android typeface from assets with a Typefaces cache 

### DIFF
--- a/src/com/buddycloud/utils/TypefacedTextView.java
+++ b/src/com/buddycloud/utils/TypefacedTextView.java
@@ -25,8 +25,8 @@ public class TypefacedTextView extends TextView {
         styledAttrs.recycle();
 
         if (fontName != null) {
-            Typeface typeface = Typeface.createFromAsset(context.getAssets(), FONTS_PATH + fontName);
-            setTypeface(typeface);
+        	// use typefaces cache to resolve memory leak issue
+            setTypeface(Typefaces.get(context, FONTS_PATH + fontName));
         }
     }
 

--- a/src/com/buddycloud/utils/Typefaces.java
+++ b/src/com/buddycloud/utils/Typefaces.java
@@ -1,0 +1,38 @@
+package com.buddycloud.utils;
+
+import java.util.Hashtable;
+
+import android.content.Context;
+import android.graphics.Typeface;
+import android.util.Log;
+
+/**
+ * Typefaces cache, this allows us to get custom typefaces
+ * without causing the android memory leak issue https://code.google.com/p/android/issues/detail?id=9904
+ * bug marked as RELEASED Jun 2013 by JBQ (guess its going into 4.3 maybe ?)
+ *
+ * Wherever you want a font just do:
+ *    view.setTypeface(Typefaces.get(context, "assets/fontname.ttf"));
+ */
+public class Typefaces {
+	private static final String TAG = "Typefaces";
+
+	private static final Hashtable<String, Typeface> cache = new Hashtable<String, Typeface>();
+
+	public static Typeface get(Context c, String assetPath) {
+		synchronized (cache) {
+			if (!cache.containsKey(assetPath)) {
+				try {
+					Typeface t = Typeface.createFromAsset(c.getAssets(),
+							assetPath);
+					cache.put(assetPath, t);
+				} catch (Exception e) {
+					Log.e(TAG, "Could not get typeface '" + assetPath
+							+ "' because " + e.getMessage());
+					return null;
+				}
+			}
+			return cache.get(assetPath);
+		}
+	}
+}


### PR DESCRIPTION
This fixes existing bug in android https://code.google.com/p/android/issues/detail?id=9904

Using a cache for the typefaces means it will only get loaded once. Also seems to have added side effect of improving UI speed (assuming it was forcing disk access to load the asset for each view using it)
